### PR TITLE
Restore MTE violation exceptions

### DIFF
--- a/linux-user/main.c
+++ b/linux-user/main.c
@@ -71,6 +71,7 @@ char *exec_path;
 char real_exec_path[PATH_MAX];
 
 bool opt_one_insn_per_tb;
+bool swallow_mte_exns;
 static const char *argv0;
 static const char *gdbstub;
 static envlist_t *envlist;
@@ -417,6 +418,11 @@ static void handle_arg_one_insn_per_tb(const char *arg)
     opt_one_insn_per_tb = true;
 }
 
+static void handle_arg_swallow_mte_exns(const char *arg)
+{
+    swallow_mte_exns = true;
+}
+
 static void handle_arg_strace(const char *arg)
 {
     enable_strace = true;
@@ -506,6 +512,9 @@ static const struct qemu_argument arg_table[] = {
     {"one-insn-per-tb",
                    "QEMU_ONE_INSN_PER_TB",  false, handle_arg_one_insn_per_tb,
      "",           "run with one guest instruction per emulated TB"},
+    {"swallow-mte-exns",
+                   "QEMU_SWALLOW_MTE_EXNS",  false, handle_arg_swallow_mte_exns,
+     "",           "do not propagate MTE violation exceptions to userspace"},
     {"strace",     "QEMU_STRACE",      false, handle_arg_strace,
      "",           "log system calls"},
     {"seed",       "QEMU_RAND_SEED",   true,  handle_arg_seed,


### PR DESCRIPTION
We need these to segfault so that the `EXPECT_VIOLATION` macro sees the violations it expects in CI. I didn't notice this locally because I was using Arch-packaged QEMU instead of our fork (specifically to work around this, but I didn't realize exactly what was happening).

This blocks [IA2-Phase2#496](https://github.com/immunant/IA2-Phase2/pull/496).